### PR TITLE
Add SPAREIRQ_* IRQs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-* No changes
+* Add SPAREIRQ_* interrupts
 
 ## [0.1.0] 2024-08-18 ([Crates.io](https://crates.io/crates/rp235x-pac/0.1.0) | [Github](https://github.com/rp-rs/rp235x-pac/releases/tag/v0.1.0))
 

--- a/src/inner/interrupt.rs
+++ b/src/inner/interrupt.rs
@@ -90,6 +90,18 @@ pub enum Interrupt {
     POWMAN_IRQ_POW = 44,
     #[doc = "45 - POWMAN_IRQ_TIMER"]
     POWMAN_IRQ_TIMER = 45,
+    #[doc = "46 - Spare IRQ 0"]
+    SPAREIRQ_IRQ_0 = 46,
+    #[doc = "47 - Spare IRQ 1"]
+    SPAREIRQ_IRQ_1 = 47,
+    #[doc = "48 - Spare IRQ 2"]
+    SPAREIRQ_IRQ_2 = 48,
+    #[doc = "49 - Spare IRQ 3"]
+    SPAREIRQ_IRQ_3 = 49,
+    #[doc = "50 - Spare IRQ 4"]
+    SPAREIRQ_IRQ_4 = 50,
+    #[doc = "51 - Spare IRQ 5"]
+    SPAREIRQ_IRQ_5 = 51,
 }
 #[doc = r" TryFromInterruptError"]
 #[derive(Debug, Copy, Clone)]
@@ -143,6 +155,12 @@ impl Interrupt {
             43 => Ok(Interrupt::PLL_USB_IRQ),
             44 => Ok(Interrupt::POWMAN_IRQ_POW),
             45 => Ok(Interrupt::POWMAN_IRQ_TIMER),
+            46 => Ok(Interrupt::SPAREIRQ_IRQ_0),
+            47 => Ok(Interrupt::SPAREIRQ_IRQ_1),
+            48 => Ok(Interrupt::SPAREIRQ_IRQ_2),
+            49 => Ok(Interrupt::SPAREIRQ_IRQ_3),
+            50 => Ok(Interrupt::SPAREIRQ_IRQ_4),
+            51 => Ok(Interrupt::SPAREIRQ_IRQ_5),
             _ => Err(TryFromInterruptError(())),
         }
     }

--- a/src/inner/mod_cortex_m.rs
+++ b/src/inner/mod_cortex_m.rs
@@ -66,6 +66,12 @@ extern "C" {
     fn PLL_USB_IRQ();
     fn POWMAN_IRQ_POW();
     fn POWMAN_IRQ_TIMER();
+    fn SPAREIRQ_IRQ_0();
+    fn SPAREIRQ_IRQ_1();
+    fn SPAREIRQ_IRQ_2();
+    fn SPAREIRQ_IRQ_3();
+    fn SPAREIRQ_IRQ_4();
+    fn SPAREIRQ_IRQ_5();
 }
 #[doc(hidden)]
 #[repr(C)]
@@ -77,7 +83,7 @@ pub union Vector {
 #[doc(hidden)]
 #[link_section = ".vector_table.interrupts"]
 #[no_mangle]
-pub static __INTERRUPTS: [Vector; 46] = [
+pub static __INTERRUPTS: [Vector; 52] = [
     Vector {
         _handler: TIMER0_IRQ_0,
     },
@@ -200,6 +206,24 @@ pub static __INTERRUPTS: [Vector; 46] = [
     Vector {
         _handler: POWMAN_IRQ_TIMER,
     },
+    Vector {
+        _handler: SPAREIRQ_IRQ_0,
+    },
+    Vector {
+        _handler: SPAREIRQ_IRQ_1,
+    },
+    Vector {
+        _handler: SPAREIRQ_IRQ_2,
+    },
+    Vector {
+        _handler: SPAREIRQ_IRQ_3,
+    },
+    Vector {
+        _handler: SPAREIRQ_IRQ_4,
+    },
+    Vector {
+        _handler: SPAREIRQ_IRQ_5,
+    },
 ];
 #[doc = r"Enumeration of all the interrupts."]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -293,6 +317,18 @@ pub enum Interrupt {
     POWMAN_IRQ_POW = 44,
     #[doc = "45 - POWMAN_IRQ_TIMER"]
     POWMAN_IRQ_TIMER = 45,
+    #[doc = "46 - Spare IRQ 0"]
+    SPAREIRQ_IRQ_0 = 46,
+    #[doc = "47 - Spare IRQ 1"]
+    SPAREIRQ_IRQ_1 = 47,
+    #[doc = "48 - Spare IRQ 2"]
+    SPAREIRQ_IRQ_2 = 48,
+    #[doc = "49 - Spare IRQ 3"]
+    SPAREIRQ_IRQ_3 = 49,
+    #[doc = "50 - Spare IRQ 4"]
+    SPAREIRQ_IRQ_4 = 50,
+    #[doc = "51 - Spare IRQ 5"]
+    SPAREIRQ_IRQ_5 = 51,
 }
 unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
     #[inline(always)]

--- a/src/inner/mod_risc_v.rs
+++ b/src/inner/mod_risc_v.rs
@@ -62,6 +62,12 @@ extern "C" {
     fn PLL_USB_IRQ();
     fn POWMAN_IRQ_POW();
     fn POWMAN_IRQ_TIMER();
+    fn SPAREIRQ_IRQ_0();
+    fn SPAREIRQ_IRQ_1();
+    fn SPAREIRQ_IRQ_2();
+    fn SPAREIRQ_IRQ_3();
+    fn SPAREIRQ_IRQ_4();
+    fn SPAREIRQ_IRQ_5();
 }
 #[doc(hidden)]
 #[repr(C)]
@@ -72,7 +78,7 @@ pub union Vector {
 #[cfg(feature = "rt")]
 #[doc(hidden)]
 #[no_mangle]
-pub static __EXTERNAL_INTERRUPTS: [Vector; 46] = [
+pub static __EXTERNAL_INTERRUPTS: [Vector; 52] = [
     Vector {
         _handler: TIMER0_IRQ_0,
     },
@@ -194,6 +200,24 @@ pub static __EXTERNAL_INTERRUPTS: [Vector; 46] = [
     },
     Vector {
         _handler: POWMAN_IRQ_TIMER,
+    },
+    Vector {
+        _handler: SPAREIRQ_IRQ_0,
+    },
+    Vector {
+        _handler: SPAREIRQ_IRQ_1,
+    },
+    Vector {
+        _handler: SPAREIRQ_IRQ_2,
+    },
+    Vector {
+        _handler: SPAREIRQ_IRQ_3,
+    },
+    Vector {
+        _handler: SPAREIRQ_IRQ_4,
+    },
+    Vector {
+        _handler: SPAREIRQ_IRQ_5,
     },
 ];
 #[doc(hidden)]

--- a/svd/RP2350.svd.patched
+++ b/svd/RP2350.svd.patched
@@ -64616,5 +64616,40 @@
         </register>
       </registers>
     </peripheral>
+    <peripheral>
+      <name>SWP_IRQ</name>
+      <description>Virtual Peripheral to access unused NVIC software interrupts</description>
+      <baseAddress>0x00000000</baseAddress>
+      <interrupt>
+        <name>spareirq_irq_0</name>
+        <description>Spare IRQ 0</description>
+        <value>46</value>
+      </interrupt>
+      <interrupt>
+        <name>spareirq_irq_1</name>
+        <description>Spare IRQ 1</description>
+        <value>47</value>
+      </interrupt>
+      <interrupt>
+        <name>spareirq_irq_2</name>
+        <description>Spare IRQ 2</description>
+        <value>48</value>
+      </interrupt>
+      <interrupt>
+        <name>spareirq_irq_3</name>
+        <description>Spare IRQ 3</description>
+        <value>49</value>
+      </interrupt>
+      <interrupt>
+        <name>spareirq_irq_4</name>
+        <description>Spare IRQ 4</description>
+        <value>50</value>
+      </interrupt>
+      <interrupt>
+        <name>spareirq_irq_5</name>
+        <description>Spare IRQ 5</description>
+        <value>51</value>
+      </interrupt>
+    </peripheral>
   </peripherals>
 </device>

--- a/svd/RP2350.yaml
+++ b/svd/RP2350.yaml
@@ -417,3 +417,27 @@ USB_DPRAM:
         _start_from_zero: true
         name: "EP_CONTROL%s"
         description: "TODO"
+
+_add:
+  SWP_IRQ:
+    description: Virtual Peripheral to access unused NVIC software interrupts
+    baseAddress: 0
+    interrupts:
+      spareirq_irq_0:
+        description: "Spare IRQ 0"
+        value: 46
+      spareirq_irq_1:
+        description: "Spare IRQ 1"
+        value: 47
+      spareirq_irq_2:
+        description: "Spare IRQ 2"
+        value: 48
+      spareirq_irq_3:
+        description: "Spare IRQ 3"
+        value: 49
+      spareirq_irq_4:
+        description: "Spare IRQ 4"
+        value: 50
+      spareirq_irq_5:
+        description: "Spare IRQ 5"
+        value: 51


### PR DESCRIPTION
Add spare IRQs to the SVD patch.

I named them SPAREIRQ_IRQ_* instead of SW*_IRQ like in the RP2040 PAC, since in this case they are explicitly named in the datasheet.

(Addresses #4)