### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -4,7 +4,7 @@ jobs:
   clippy-check-arm:
     runs-on: ubuntu-20.04
     env:
-      RUSTFLAGS: "-D warnings"
+      RUSTFLAGS: "-D warnings -Aclippy::needless_lifetimes"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -15,7 +15,7 @@ jobs:
   clippy-check-riscv:
     runs-on: ubuntu-20.04
     env:
-      RUSTFLAGS: "-D warnings"
+      RUSTFLAGS: "-D warnings -Aclippy::needless_lifetimes"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/svd/RP2350.yaml
+++ b/svd/RP2350.yaml
@@ -5,22 +5,22 @@ DMA:
     _modify:
       "CHAIN_TO":
         description: "When this channel completes, it will trigger the channel indicated by CHAIN_TO. Disable by setting CHAIN_TO = _(this channel)_. \\n
-        Reset value is 0, which means for channels 1 and above the default will be to chain to channel 0 - set this field to avoid this behaviour."
+          Reset value is 0, which means for channels 1 and above the default will be to chain to channel 0 - set this field to avoid this behaviour."
   CH0_AL1_CTRL:
     _modify:
       "CHAIN_TO":
         description: "When this channel completes, it will trigger the channel indicated by CHAIN_TO. Disable by setting CHAIN_TO = _(this channel)_. \\n
-        Reset value is 0, which means for channels 1 and above the default will be to chain to channel 0 - set this field to avoid this behaviour."
+          Reset value is 0, which means for channels 1 and above the default will be to chain to channel 0 - set this field to avoid this behaviour."
   CH0_AL2_CTRL:
     _modify:
       "CHAIN_TO":
         description: "When this channel completes, it will trigger the channel indicated by CHAIN_TO. Disable by setting CHAIN_TO = _(this channel)_. \\n
-        Reset value is 0, which means for channels 1 and above the default will be to chain to channel 0 - set this field to avoid this behaviour."
+          Reset value is 0, which means for channels 1 and above the default will be to chain to channel 0 - set this field to avoid this behaviour."
   CH0_AL3_CTRL:
     _modify:
       "CHAIN_TO":
         description: "When this channel completes, it will trigger the channel indicated by CHAIN_TO. Disable by setting CHAIN_TO = _(this channel)_. \\n
-        Reset value is 0, which means for channels 1 and above the default will be to chain to channel 0 - set this field to avoid this behaviour."
+          Reset value is 0, which means for channels 1 and above the default will be to chain to channel 0 - set this field to avoid this behaviour."
 
   "CH*_CTRL*":
     "TREQ_SEL":

--- a/update.sh
+++ b/update.sh
@@ -6,11 +6,11 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 set -exuo pipefail
 
-cargo install --version 0.33.4 svd2rust
-cargo install --version 0.12.1  form
+cargo install --version 0.33.4 svd2rust --locked
+cargo install --version 0.12.1  form --locked
 rustup component add rustfmt
 if [ "$SVDTOOLS" == "svdtools" ]; then
-    cargo install --version 0.3.17 svdtools
+    cargo install --version 0.3.17 svdtools --locked
 else
     python3 -mvenv --clear .venv
     source .venv/bin/activate

--- a/update.sh
+++ b/update.sh
@@ -10,7 +10,7 @@ cargo install --version 0.33.4 svd2rust --locked
 cargo install --version 0.12.1  form --locked
 rustup component add rustfmt
 if [ "$SVDTOOLS" == "svdtools" ]; then
-    cargo install --version 0.3.17 svdtools --locked
+    cargo install --version 0.3.20 svdtools --locked
 else
     python3 -mvenv --clear .venv
     source .venv/bin/activate


### PR DESCRIPTION
Disable needless_lifetimes needed to ignore this warning:
```
error: the following explicit lifetimes could be elided: 'a
   --> src/inner/generic.rs:209:6
    |
209 | impl<'a, REG, const WI: u8, FI, Safety> FieldWriter<'a, REG, WI, FI, Safety>
    |      ^^                                             ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
help: elide the lifetimes
    |
209 - impl<'a, REG, const WI: u8, FI, Safety> FieldWriter<'a, REG, WI, FI, Safety>
209 + impl<REG, const WI: u8, FI, Safety> FieldWriter<'_, REG, WI, FI, Safety>
    |

error: could not compile `rp235x-pac` (lib) due to 1 previous error
Error: Process completed with exit code 101.
```

Locked version of svd2rust is needed to avoid an issue with proc-macro2:
```
[WARN  svd2rust::generate::register] Missing description for register RESET
thread 'main' panicked at /home/nine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.92/src/lib.rs:849:13:
unsupported proc macro punctuation character '{'
```

Need to indent a multiline string in YAML to fix this:
```
+ svdtools patch svd/RP2350.yaml
[2024-12-08T07:35:35Z ERROR svdtools::cli] by svdtools (0.3.20)
    
    Caused by:
        invalid indentation in quoted scalar at byte 96 line 7 column 22
```

Need to update svdtools to 0.3.20 to get a new version of `time` to avoid this error:
```
error[E0282]: type annotations needed for `Box<_>`
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.31/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
   = note: this is an inference error on crate `time` caused by an API change in Rust 1.80.0; update `time` to version `>=0.3.35` by calling `cargo update`
```