### PR TITLE
Fix #11:  restore missing irqs to the `device.x` file by securing generated file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-* Add SPAREIRQ_* interrupts
+* Add `SW*_IRQ` interrupts
 
 ## [0.1.0] 2024-08-18 ([Crates.io](https://crates.io/crates/rp235x-pac/0.1.0) | [Github](https://github.com/rp-rs/rp235x-pac/releases/tag/v0.1.0))
 

--- a/device.x
+++ b/device.x
@@ -42,4 +42,10 @@ PROVIDE(PLL_SYS_IRQ = DefaultHandler);
 PROVIDE(PLL_USB_IRQ = DefaultHandler);
 PROVIDE(POWMAN_IRQ_POW = DefaultHandler);
 PROVIDE(POWMAN_IRQ_TIMER = DefaultHandler);
+PROVIDE(SW0_IRQ = DefaultHandler);
+PROVIDE(SW1_IRQ = DefaultHandler);
+PROVIDE(SW2_IRQ = DefaultHandler);
+PROVIDE(SW3_IRQ = DefaultHandler);
+PROVIDE(SW4_IRQ = DefaultHandler);
+PROVIDE(SW5_IRQ = DefaultHandler);
 

--- a/sortFieldsAlphaNum.sh
+++ b/sortFieldsAlphaNum.sh
@@ -35,7 +35,9 @@ for ((i = 0; i < ${#alphaTargets[@]}; i++)); do
   # Calculate the tail number needed to crop to blockEnd
   blockTail=$((maxLen-blockEnd))
 
-  # This will replace the parts that need to be sorted.
+  # This will replace the parts that need to be sorted. Ensure that sort ordering is 
+  # consistent irrespective of the user's locale by using the "C" locale.
+  export LC_ALL=C
   toReplace=$(cat ${FILE} | grep "${alphaTargets[$i]}" -A $blockEndLine | tail -n $blockEndLine)
   if [ "$(uname)" == "Darwin" ]; then
     alphabetized=$(echo "$toReplace" | sed '$!N;s/\n/ /' | sort | sed 's/     /\n    /')

--- a/update.sh
+++ b/update.sh
@@ -33,6 +33,7 @@ rustfmt inner/lib.rs
 mv inner/lib.rs inner/mod_cortex_m.rs
 rm -rf ${SCRIPT_DIR}/src/inner
 mv inner ${SCRIPT_DIR}/src
+mv device.x ${SCRIPT_DIR}
 popd
 rm -rf ${tmp_dir}
 


### PR DESCRIPTION
This PR fixes #11.

Simple change to the update script to secure the `device.x` file that svd2rust generated for us.

A couple of other changes that I hope are uncontroversial:

  1. I got some unintended changes to the ordering of the items in the Peripherals struct when I was testing locally that I tracked down to my locale, so I've enforced C locale in the sorting script. I have only tested locally on Ubuntu 24.04 and in the GH Actions and not on MacOS. However, I can't think it will behave differently on the "Darwin" arm of the sort.
  2. I have aligned the naming in the changelog with the naming that people settled on last time around (_e.g._ `SW0_IRQ` rather than `SPAREIRQ0_IRQ`)

Hope that's useful!