### PR TITLE
Set MSRV to 1.81.0 and run clippy on that version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,7 +2,7 @@ on: [push, pull_request]
 name: Build and Test check
 jobs:
   check-arm:
-    name: cargo-check
+    name: cargo-check (ARM)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -11,11 +11,31 @@ jobs:
           target: thumbv8m.main-none-eabihf
       - run: cargo build --target=thumbv8m.main-none-eabihf
   check-riscv:
-    name: cargo-check
+    name: cargo-check (RISC-V)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: riscv32imac-unknown-none-elf
+      - run: cargo build --target=riscv32imac-unknown-none-elf
+  check-arm-msrv:
+    name: cargo-check on MSRV (ARM)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          target: thumbv8m.main-none-eabihf
+          toolchain: 1.81.0
+      - run: cargo build --target=thumbv8m.main-none-eabihf
+  check-riscv-msrv:
+    name: cargo-check on MSRV (RISC-V)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          target: riscv32imac-unknown-none-elf
+          toolchain: 1.81.0
       - run: cargo build --target=riscv32imac-unknown-none-elf

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,9 +7,10 @@ jobs:
       RUSTFLAGS: "-D warnings -Aclippy::needless_lifetimes"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
           target: thumbv8m.main-none-eabihf
+          toolchain: 1.81.0
           components: clippy
       - run: cargo clippy --target=thumbv8m.main-none-eabihf
   clippy-check-riscv:
@@ -18,8 +19,9 @@ jobs:
       RUSTFLAGS: "-D warnings -Aclippy::needless_lifetimes"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
           target: riscv32imac-unknown-none-elf
+          toolchain: 1.81.0
           components: clippy
       - run: cargo clippy --target=riscv32imac-unknown-none-elf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "BSD-3-Clause"
 name = "rp235x-pac"
 repository = "https://github.com/rp-rs/rp235x-pac"
 version = "0.1.0"
+rust-version = "1.81.0"
 
 [package.metadata.docs.rs]
 features = ["rt"]


### PR DESCRIPTION
This should fix clippy errors in CI, as seen in https://github.com/rp-rs/rp235x-pac/actions/runs/18171672578

I chose 1.81.0 mostly arbitrarily, because it's also the current MSRV of rp-hal.
It's quite likely that older rust versions work as well.